### PR TITLE
Handle Foody webhook events

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const dotenv = require('dotenv');
 const blingWebhook = require('./routes/blingWebhook');
+const foodyWebhook = require('./routes/foodyWebhook');
 const { exchangeAuthorizationCodeForToken } = require('./services/blingAuthService');
 
 dotenv.config();
@@ -15,6 +16,9 @@ app.use(bodyParser.json());
 
 // Rota para receber webhooks do Bling
 app.use('/webhook', blingWebhook);
+
+// Rota para receber webhooks da Foody
+app.use('/webhook/foody', foodyWebhook);
 
 // Rota de callback do Bling para troca de authorization_code automaticamente
 app.get('/oauth/callback', async (req, res) => {

--- a/src/routes/foodyWebhook.js
+++ b/src/routes/foodyWebhook.js
@@ -1,12 +1,28 @@
 const express = require('express');
 const router = express.Router();
+const { atualizarSituacaoPedidoBling } = require('../services/blingApiService');
 
-router.post('/', (req, res) => {
+router.post('/', async (req, res) => {
   const webhookData = req.body;
 
   console.log('📡 Webhook recebido da Foody:', JSON.stringify(webhookData, null, 2));
 
-  res.status(200).send('OK');
+  try {
+    const orderId = webhookData?.orderId || webhookData?.order?.id;
+    const statusId = webhookData?.statusId || webhookData?.status;
+
+    if (!orderId || !statusId) {
+      return res.status(400).send('Dados do webhook inválidos.');
+    }
+
+    console.log(`🚀 Atualizando status do pedido ${orderId} para ${statusId} no Bling`);
+    await atualizarSituacaoPedidoBling(orderId, statusId);
+
+    res.status(200).send('OK');
+  } catch (error) {
+    console.error('❌ Erro ao processar webhook da Foody:', error.message);
+    res.status(500).send('Erro ao processar webhook.');
+  }
 });
 
 module.exports = router;

--- a/src/services/blingApiService.js
+++ b/src/services/blingApiService.js
@@ -33,4 +33,21 @@ async function consultarContatoBling(contatoId) {
   return response.data;
 }
 
-module.exports = { consultarPedidoBling, consultarContatoBling };
+async function atualizarSituacaoPedidoBling(pedidoId, situacaoId) {
+  const token = await getBlingAccessToken();
+
+  const response = await axios.post(
+    `${BLING_API_BASE_URL}/pedidos/vendas/${pedidoId}/situacoes`,
+    { idSituacao: situacaoId },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      }
+    }
+  );
+
+  return response.data;
+}
+
+module.exports = { consultarPedidoBling, consultarContatoBling, atualizarSituacaoPedidoBling };


### PR DESCRIPTION
## Summary
- wire Foody webhook router in the main app
- parse Foody webhook payload and update Bling status
- expose Bling API helper to update order status

## Testing
- `npm install`
- `node src/app.js` *(server starts)*

------
https://chatgpt.com/codex/tasks/task_e_684a2b86be80832682419cc048993bc4