### PR TITLE
Add functions to update order status

### DIFF
--- a/src/services/blingApiService.js
+++ b/src/services/blingApiService.js
@@ -33,4 +33,21 @@ async function consultarContatoBling(contatoId) {
   return response.data;
 }
 
-module.exports = { consultarPedidoBling, consultarContatoBling };
+async function atualizarStatusPedidoBling(pedidoId, status) {
+  const token = await getBlingAccessToken();
+
+  const response = await axios.post(
+    `${BLING_API_BASE_URL}/pedidos/vendas/${pedidoId}/situacoes`,
+    { situacao: status },
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      }
+    }
+  );
+
+  return response.data;
+}
+
+module.exports = { consultarPedidoBling, consultarContatoBling, atualizarStatusPedidoBling };

--- a/src/services/foodyService.js
+++ b/src/services/foodyService.js
@@ -31,4 +31,31 @@ async function enviarPedidoFoody(payload) {
   }
 }
 
-module.exports = { enviarPedidoFoody };
+async function atualizarStatusPedidoFoody(orderId, status) {
+  const token = await getAccessToken();
+
+  try {
+    const response = await axios.put(
+      `${FOODY_URL}/logistics/delivery/${orderId}/status`,
+      { status },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+
+    console.log('✅ Status do pedido atualizado:', response.data);
+    return response.data;
+  } catch (error) {
+    console.error('❌ Erro ao atualizar status do pedido:', {
+      status: error.response?.status,
+      headers: error.response?.headers,
+      data: error.response?.data,
+      message: error.message
+    });
+  }
+}
+
+module.exports = { enviarPedidoFoody, atualizarStatusPedidoFoody };


### PR DESCRIPTION
## Summary
- add `atualizarStatusPedidoBling` to update the situation of a Bling order
- add `atualizarStatusPedidoFoody` to call Foody's status endpoint

## Testing
- `npm install`
- `node -e "require('./src/services/foodyService.js'); require('./src/services/blingApiService.js');"`

------
https://chatgpt.com/codex/tasks/task_e_684a2b94ded883269e7b220fb6bd1f8d