### PR TITLE
Fix corrupted Foody webhook files

### DIFF
--- a/src/routes/foodyWebhook.js
+++ b/src/routes/foodyWebhook.js
@@ -1,43 +1,26 @@
 const express = require('express');
-const { atualizarStatusPedidoBling } = require('../services/blingApiService');
 const router = express.Router();
 const { atualizarSituacaoPedidoBling } = require('../services/blingApiService');
 
 router.post('/', async (req, res) => {
- codex/implement-foody-and-bling-webhook-endpoints
-  const { orderId, status } = req.body;
   const webhookData = req.body;
-  main
 
-  console.log('📡 Webhook recebido da Foody:', JSON.stringify(req.body, null, 2));
+  console.log('📡 Webhook recebido da Foody:', JSON.stringify(webhookData, null, 2));
 
- codex/implement-foody-and-bling-webhook-endpoints
-  if (!orderId || !status) {
+  const orderId = webhookData?.orderId || webhookData?.order?.id;
+  const statusId = webhookData?.statusId || webhookData?.status;
+
+  if (!orderId || !statusId) {
     console.error('❌ Payload da Foody incompleto.');
     return res.status(400).send('Dados inválidos.');
   }
 
   try {
-    await atualizarStatusPedidoBling(orderId, status);
-    res.status(200).send('Status enviado ao Bling.');
-  } catch (error) {
-    console.error('❌ Erro ao atualizar status no Bling:', error.message);
-
-  try {
-    const orderId = webhookData?.orderId || webhookData?.order?.id;
-    const statusId = webhookData?.statusId || webhookData?.status;
-
-    if (!orderId || !statusId) {
-      return res.status(400).send('Dados do webhook inválidos.');
-    }
-
     console.log(`🚀 Atualizando status do pedido ${orderId} para ${statusId} no Bling`);
     await atualizarSituacaoPedidoBling(orderId, statusId);
-
     res.status(200).send('OK');
   } catch (error) {
     console.error('❌ Erro ao processar webhook da Foody:', error.message);
- main
     res.status(500).send('Erro ao processar webhook.');
   }
 });

--- a/src/services/blingApiService.js
+++ b/src/services/blingApiService.js
@@ -5,22 +5,19 @@ const BLING_API_BASE_URL = process.env.BLING_API_BASE_URL || 'https://api.bling.
 
 async function consultarPedidoBling(pedidoId, numeroPedido) {
   const token = await getBlingAccessToken();
-    
   const response = await axios.get(
-      `${BLING_API_BASE_URL}/pedidos/vendas/${pedidoId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
+    `${BLING_API_BASE_URL}/pedidos/vendas/${pedidoId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`
       }
-    );
-
+    }
+  );
   return response.data;
 }
 
 async function consultarContatoBling(contatoId) {
   const token = await getBlingAccessToken();
-
   const response = await axios.get(
     `${BLING_API_BASE_URL}/contatos/${contatoId}`,
     {
@@ -29,18 +26,11 @@ async function consultarContatoBling(contatoId) {
       }
     }
   );
-
   return response.data;
 }
 
- codex/add-atualizarstatuspedidobling-and-atualizarstatuspedidofood
- codex/add-atualizarstatuspedidobling-and-atualizarstatuspedidofood
- {
-
-codex/implement-foody-and-bling-webhook-endpoints
 async function atualizarStatusPedidoBling(orderId, status) {
   const token = await getBlingAccessToken();
-
   try {
     const response = await axios.patch(
       `${BLING_API_BASE_URL}/pedidos/vendas/${orderId}`,
@@ -51,35 +41,19 @@ async function atualizarStatusPedidoBling(orderId, status) {
         }
       }
     );
-
     console.log('✅ Status do pedido atualizado no Bling:', response.data);
     return response.data;
   } catch (error) {
-    console.error(
-      '❌ Erro ao atualizar status no Bling:',
-      error.response?.data || error.message
-    );
+    console.error('❌ Erro ao atualizar status no Bling:', error.response?.data || error.message);
     throw new Error('Falha ao atualizar status no Bling');
   }
 }
 
-module.exports = {
-  consultarPedidoBling,
-  consultarContatoBling,
-  atualizarStatusPedidoBling
-};
-
- main
 async function atualizarSituacaoPedidoBling(pedidoId, situacaoId) {
- main
   const token = await getBlingAccessToken();
-
   const response = await axios.post(
     `${BLING_API_BASE_URL}/pedidos/vendas/${pedidoId}/situacoes`,
- codex/add-atualizarstatuspedidobling-and-atualizarstatuspedidofood
-    { situacao: status },
     { idSituacao: situacaoId },
- main
     {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -87,15 +61,12 @@ async function atualizarSituacaoPedidoBling(pedidoId, situacaoId) {
       }
     }
   );
-
   return response.data;
 }
 
- codex/add-atualizarstatuspedidobling-and-atualizarstatuspedidofood
- codex/add-atualizarstatuspedidobling-and-atualizarstatuspedidofood
-module.exports = { consultarPedidoBling, consultarContatoBling, atualizarStatusPedidoBling };
-
-
-module.exports = { consultarPedidoBling, consultarContatoBling, atualizarSituacaoPedidoBling };
- main
-main
+module.exports = {
+  consultarPedidoBling,
+  consultarContatoBling,
+  atualizarStatusPedidoBling,
+  atualizarSituacaoPedidoBling
+};

--- a/src/services/foodyService.js
+++ b/src/services/foodyService.js
@@ -35,11 +35,7 @@ async function atualizarStatusPedidoFoody(orderId, status) {
   const token = await getAccessToken();
 
   try {
- codex/add-atualizarstatuspedidobling-and-atualizarstatuspedidofood
-    const response = await axios.put(
-
     const response = await axios.post(
- main
       `${FOODY_URL}/logistics/delivery/${orderId}/status`,
       { status },
       {
@@ -50,26 +46,16 @@ async function atualizarStatusPedidoFoody(orderId, status) {
       }
     );
 
- codex/add-atualizarstatuspedidobling-and-atualizarstatuspedidofood
-    console.log('✅ Status do pedido atualizado:', response.data);
-    return response.data;
-  } catch (error) {
-    console.error('❌ Erro ao atualizar status do pedido:', {
-
     console.log('✅ Status do pedido atualizado na Foody:', response.data);
     return response.data;
   } catch (error) {
     console.error('❌ Erro ao atualizar status na Foody:', {
- main
       status: error.response?.status,
       headers: error.response?.headers,
       data: error.response?.data,
       message: error.message
     });
- codex/add-atualizarstatuspedidobling-and-atualizarstatuspedidofood
-
     throw new Error('Falha ao atualizar status na Foody');
- main
   }
 }
 


### PR DESCRIPTION
## Summary
- clean foody webhook route
- fix Foody service for status update
- rewrite Bling API service without leftover merge text

## Testing
- `npm install`
- `node -e "require('./src/routes/foodyWebhook.js')"`
- `node -e "require('./src/services/foodyService.js')"`
- `node -e "require('./src/services/blingApiService.js')"`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a360bb0b48326aad14a85e05c98dc